### PR TITLE
Fixed problem with Connection.close() that prevented graceful exit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk7
+install: mvn install -Dmaven.compiler.target=1.7 -Dmaven.compiler.source=1.7 -DskipTests=true
+script: mvn test -Dmaven.compiler.target=1.7 -Dmaven.compiler.source=1.7

--- a/README.md
+++ b/README.md
@@ -2,14 +2,21 @@
 
 Java client library for the [NATS messaging system](http://nats.io).
 
+Version: 0.5.2_mring
+
 ## Supported Platforms
 
 ```javascript
-java_nats currently supports following Java Platforms :
+This version of java_nats currently supports following Java Platforms :
 
-- Java Platform, Standard Edition 6 (Java SE 6)
 - Java Platform, Standard Edition 7 (Java SE 7)
+- Java Platform, Standard Edition 8 (Java SE 8)
 ```
+
+## Upcoming Changes and Additions
+- Fix any bugs found by Coverity static analysis
+- Add common base client classes
+- Add support for binary messages
 
 ## Getting Started
 
@@ -36,7 +43,7 @@ Or adding dependency to Maven pom.xml
 <dependency>
 	<groupId>com.github.tyagihas</groupId>
 	<artifactId>java_nats</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2_mring</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Java_Nats
+# Java_Nats ![build status](https://travis-ci.org/mring33621/java_nats.svg?branch=master)
 
 Java client library for the [NATS messaging system](http://nats.io).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Java client library for the [NATS messaging system](http://nats.io).
 
-Version: 0.5.2_mring
+Now supports both String and raw binary messages!
+
+Version: 0.5.3_mring
 
 ## Supported Platforms
 
@@ -16,7 +18,7 @@ This version of java_nats currently supports following Java Platforms :
 ## Upcoming Changes and Additions
 - Fix any bugs found by Coverity static analysis
 - Add common base client classes
-- Add support for binary messages
+- ~~Add support for binary messages~~
 
 ## Getting Started
 
@@ -43,7 +45,7 @@ Or adding dependency to Maven pom.xml
 <dependency>
 	<groupId>com.github.tyagihas</groupId>
 	<artifactId>java_nats</artifactId>
-	<version>0.5.2_mring</version>
+	<version>0.5.3_mring</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.github.tyagihas</groupId>
 	<artifactId>java_nats</artifactId>
 	<packaging>jar</packaging>
-	<version>0.5.1_mring</version>
+	<version>0.5.2_mring</version>
 	<name>Java Nats Client</name>
 	<description>Java client for Nats</description>
 	<url>https://github.com/mring33621/java_nats.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.github.tyagihas</groupId>
 	<artifactId>java_nats</artifactId>
 	<packaging>jar</packaging>
-	<version>0.5.2_mring</version>
+	<version>0.5.3_mring</version>
 	<name>Java Nats Client</name>
 	<description>Java client for Nats</description>
 	<url>https://github.com/mring33621/java_nats.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,13 @@
 	<groupId>com.github.tyagihas</groupId>
 	<artifactId>java_nats</artifactId>
 	<packaging>jar</packaging>
-	<version>0.5.1</version>
+	<version>0.5.1_mring</version>
 	<name>Java Nats Client</name>
 	<description>Java client for Nats</description>
-	<url>https://github.com/tyagihas/java_nats.git</url>
+	<url>https://github.com/mring33621/java_nats.git</url>
 	<properties>
  		<java.version>1.7</java.version>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<licenses>
 		<license>
@@ -23,11 +24,15 @@
   		<name>Teppei Yagihashi</name>
   		<email>tyagihas@gmail.com</email>
   		</developer>
+                <developer>
+  		<name>Matthew Ring</name>
+  		<email>angryduckstudio@gmail.com</email>
+  		</developer>
   	</developers>
 	<scm>
-		<connection>scm:git:git@github.com:tyagihas/java_nats.git</connection>
-		<developerConnection>scm:git:git@github.com:tyagihas/java_nats.git</developerConnection>
-		<url>git@github.com:tyagihas/java_nats.git</url>
+		<connection>scm:git:git@github.com:mring33621/java_nats.git</connection>
+		<developerConnection>scm:git:git@github.com:mring33621/java_nats.git</developerConnection>
+		<url>git@github.com:mring33621/java_nats.git</url>
 	</scm>
 	<build>
 		<plugins>
@@ -75,7 +80,7 @@
       		<executions>
         		<execution>
           		<id>sign-artifacts</id>
-          		<phase>verify</phase>
+          		<phase>none</phase>
           		<goals>
             		<goal>sign</goal>
           		</goals>

--- a/src/main/java/org/nats/Connection.java
+++ b/src/main/java/org/nats/Connection.java
@@ -147,6 +147,7 @@ public class Connection {
 	protected Connection(Properties popts, MsgHandler handler) throws IOException, InterruptedException {
 		self = this;
 		processor = new MsgProcessor();
+                processor.setDaemon(true);
 		sendBuffer = ByteBuffer.allocateDirect(INIT_BUFFER_SIZE);
 		lastPos = 0;
 		receiveBuffer = ByteBuffer.allocateDirect(INIT_BUFFER_SIZE);
@@ -277,10 +278,11 @@ public class Connection {
 	public void close(boolean flush) throws IOException {
 		if (flush)
 			flush();
+                opts.put("reconnect", Boolean.FALSE);
+                timer.cancel();
 		channel.close();
 		numConnections--;
 		processor.interrupt();
-		timer.purge();
 	}
 
 	/**

--- a/src/main/java/org/nats/Connection.java
+++ b/src/main/java/org/nats/Connection.java
@@ -751,7 +751,9 @@ public class Connection {
 						receiveBuffer.get(buf, 0, payload_length + 2);
 						on_msg(new String(buf, 0, payload_length)); 
 						pos = 0;
-						status = AWAITING_CONTROL;					
+						status = AWAITING_CONTROL;
+						subject = null;
+						optReply = null;
 						break;
 					}
 				}

--- a/src/main/java/org/nats/Connection.java
+++ b/src/main/java/org/nats/Connection.java
@@ -21,9 +21,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * by calling {@link #connect(java.util.Properties popts)} multiple times.
  * 
  * @author Teppei Yagihashi
+ * @author Matthew Ring
  *
  */
-public class Connection {
+public class Connection implements AutoCloseable {
 
 	private static final String version = "0.5.2_mring";
 	

--- a/src/main/java/org/nats/MsgHandler.java
+++ b/src/main/java/org/nats/MsgHandler.java
@@ -10,6 +10,7 @@ public abstract class MsgHandler {
 	private static final Class<?>[] ARITY2 = {String.class, String.class};
 	private static final Class<?>[] ARITY3 = {String.class, String.class, String.class};
 	private static final Class<?>[] OBJ = {Object.class};
+        private static final Class<?>[] BIN = {byte[].class};
 
 	private static final String className = "org.nats.MsgHandler";
 	public Thread caller;
@@ -24,6 +25,7 @@ public abstract class MsgHandler {
 	public void execute(String msg, String reply) {}
 	public void execute(String msg, String reply, String subject) {}		
 	public void execute(Object o) {}
+        public void execute(byte[] binMsg) {}
 	
 	private void verifyArity() {
 		try {
@@ -37,6 +39,8 @@ public abstract class MsgHandler {
 				arity = 3;
 			else if (!getClass().getMethod("execute", OBJ).getDeclaringClass().getName().equals(className))
 				arity = -1;
+                        else if (!getClass().getMethod("execute", BIN).getDeclaringClass().getName().equals(className))
+				arity = -2;
 		} catch (Exception e) {
 			e.printStackTrace();
 		}			

--- a/src/main/java/org/nats/SerializationUtils.java
+++ b/src/main/java/org/nats/SerializationUtils.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Matthew Ring
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.nats;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Code taken from http://stackoverflow.com/questions/3736058/java-object-to-byte-and-byte-to-object-converter-for-tokyo-cabinet
+ * @author Thomas Mueller
+ * @author Matthew Ring
+ */
+public class SerializationUtils {
+
+    public static byte[] serialize(Object obj) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ObjectOutputStream os = new ObjectOutputStream(out);
+        os.writeObject(obj);
+        return out.toByteArray();
+    }
+
+    public static Object deserialize(byte[] data) throws IOException, ClassNotFoundException {
+        ByteArrayInputStream in = new ByteArrayInputStream(data);
+        ObjectInputStream is = new ObjectInputStream(in);
+        return is.readObject();
+    }
+}


### PR DESCRIPTION
While writing NATS custom processors for Apache NiFi, I found and fixed this issue with Connection.close(). Without this change, I'd get the following error when closing a NATS Connection:

java.nio.channels.ClosedByInterruptException
    at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
    at sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:659)
    at java.nio.channels.SocketChannel.open(SocketChannel.java:189)
    at org.nats.Connection.connect(Connection.java:211)
    at org.nats.Connection.reconnect(Connection.java:613)
    at org.nats.Connection.access$300(Connection.java:20)
    at org.nats.Connection$MsgProcessor.run(Connection.java:703)
java.lang.InterruptedException: sleep interrupted
    at java.lang.Thread.sleep(Native Method)
    at org.nats.Connection.reconnect(Connection.java:625)
    at org.nats.Connection.access$300(Connection.java:20)
    at org.nats.Connection$MsgProcessor.run(Connection.java:703)

After which, the involved thread(s) would not exit.
